### PR TITLE
feat: support nullable input type arguments

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,22 +35,23 @@ function validateOpts (opts) {
   return opts
 }
 
-function inferJSONSchemaType (type) {
+function inferJSONSchemaType (type, isNonNull) {
   if (type === GraphQLString) {
-    return { type: 'string' }
+    return isNonNull ? { type: 'string' } : { type: ['string', 'null'] }
   }
   if (type === GraphQLInt) {
-    return { type: 'integer' }
+    return isNonNull ? { type: 'integer' } : { type: ['integer', 'null'] }
   }
   if (type === GraphQLFloat) {
-    return { type: 'number' }
+    return isNonNull ? { type: 'number' } : { type: ['number', 'null'] }
   }
   return {}
 }
 
 function getTypeInfo (graphQLType) {
-  const type = isNonNullType(graphQLType.type) ? graphQLType.type.ofType : graphQLType.type
-  return [type, getNamedType(type)]
+  const isNonNull = isNonNullType(graphQLType.type)
+  const type = isNonNull ? graphQLType.type.ofType : graphQLType.type
+  return [type, getNamedType(type), isNonNull]
 }
 
 module.exports = {

--- a/lib/validators/json-schema-validator.js
+++ b/lib/validators/json-schema-validator.js
@@ -10,9 +10,9 @@ const { kAjv, kOpts, kOverrideFieldResolver, kValidationSchema, kBuildArgumentsS
 const { getTypeInfo, inferJSONSchemaType } = require('../utils')
 
 class JSONSchemaValidator extends Validator {
-  [kValidationSchema] (type, namedType, typeValidation, id) {
+  [kValidationSchema] (type, namedType, isNonNull, typeValidation, id) {
     let builtValidationSchema = {
-      ...inferJSONSchemaType(namedType),
+      ...inferJSONSchemaType(namedType, isNonNull),
       $id: id
     }
 
@@ -26,7 +26,7 @@ class JSONSchemaValidator extends Validator {
       }
     // If we have an array of scalars, set the array type and infer the items
     } else if (isListType(type)) {
-      let items = { ...inferJSONSchemaType(namedType), ...builtValidationSchema.items }
+      let items = { ...inferJSONSchemaType(namedType, isNonNull), ...builtValidationSchema.items }
       if (typeValidation !== null) {
         items = { ...items, ...typeValidation.items }
       }
@@ -50,11 +50,11 @@ class JSONSchemaValidator extends Validator {
     }
 
     for (const argument of schemaTypeField.args) {
-      const [argumentType, namedArgumentType] = getTypeInfo(argument)
+      const [argumentType, namedArgumentType, isNonNull] = getTypeInfo(argument)
       const argumentValidation = fieldValidation !== null ? fieldValidation[argument.name] || null : null
       const id = `https://mercurius.dev/validation/${typeName}/${fieldName}/${argument.name}`
 
-      const argumentValidationSchema = this[kValidationSchema](argumentType, namedArgumentType, argumentValidation, id)
+      const argumentValidationSchema = this[kValidationSchema](argumentType, namedArgumentType, isNonNull, argumentValidation, id)
 
       fieldArgumentsValidationSchema.properties[argument.name] = argumentValidationSchema
     }
@@ -64,10 +64,10 @@ class JSONSchemaValidator extends Validator {
   }
 
   [kBuildInputTypeFieldSchema] (typeName, fieldName, schemaTypeField, fieldValidation) {
-    const [fieldType, namedFieldType] = getTypeInfo(schemaTypeField)
+    const [fieldType, namedFieldType, isNonNull] = getTypeInfo(schemaTypeField)
     const id = `https://mercurius.dev/validation/${typeName}/${fieldName}`
 
-    const builtFieldValidationSchema = this[kValidationSchema](fieldType, namedFieldType, fieldValidation, id)
+    const builtFieldValidationSchema = this[kValidationSchema](fieldType, namedFieldType, isNonNull, fieldValidation, id)
 
     // Only consider fields where we have inferred the type to avoid any AJV errors
     if (fieldValidation !== null) {
@@ -76,7 +76,7 @@ class JSONSchemaValidator extends Validator {
       }
     }
 
-    if (typeof builtFieldValidationSchema.type === 'string') {
+    if (typeof builtFieldValidationSchema.type === 'string' || Array.isArray(builtFieldValidationSchema.type)) {
       return builtFieldValidationSchema
     }
     return null

--- a/test/advanced-validation.js
+++ b/test/advanced-validation.js
@@ -167,7 +167,7 @@ t.test('Advanced', t => {
                   schema: 1,
                   parentSchema: {
                     minLength: 1,
-                    type: 'string',
+                    type: ['string', 'null'],
                     $id: 'https://mercurius.dev/validation/Filters/text'
                   },
                   data: ''
@@ -186,7 +186,7 @@ t.test('Advanced', t => {
                     type: 'array',
                     $id: 'https://mercurius.dev/validation/ArrayFilters/values',
                     items: {
-                      type: 'string'
+                      type: ['string', 'null']
                     }
                   },
                   data: []
@@ -223,7 +223,7 @@ t.test('Advanced', t => {
                     type: 'array',
                     $id: 'https://mercurius.dev/validation/Query/messages/arrayScalarFilters',
                     items: {
-                      type: 'string'
+                      type: ['string', 'null']
                     }
                   },
                   data: [
@@ -552,7 +552,7 @@ t.test('Advanced', t => {
                     type: 'array',
                     $id: 'https://mercurius.dev/validation/Query/messages/arrayScalarFilters',
                     items: {
-                      type: 'string'
+                      type: ['string', 'null']
                     }
                   },
                   data: [

--- a/test/directive-validation.js
+++ b/test/directive-validation.js
@@ -255,7 +255,7 @@ t.test('With directives', t => {
                 schema: 1,
                 parentSchema: {
                   $id: 'https://mercurius.dev/validation/Filters/text',
-                  type: 'string',
+                  type: ['string', 'null'],
                   minLength: 1
                 },
                 data: ''
@@ -394,7 +394,7 @@ t.test('With directives', t => {
                 schema: 1,
                 parentSchema: {
                   $id: 'https://mercurius.dev/validation/Filters/text',
-                  type: 'string',
+                  type: ['string', 'null'],
                   minLength: 1
                 },
                 data: ''
@@ -500,7 +500,7 @@ t.test('With directives', t => {
                   schema: 1,
                   parentSchema: {
                     $id: 'https://mercurius.dev/validation/Filters/text',
-                    type: 'string',
+                    type: ['string', 'null'],
                     minLength: 1
                   },
                   data: ''
@@ -583,7 +583,7 @@ t.test('With directives', t => {
                   schema: 1,
                   parentSchema: {
                     $id: 'https://mercurius.dev/validation/Filters/text',
-                    type: 'string',
+                    type: ['string', 'null'],
                     minLength: 1
                   },
                   data: ''
@@ -670,7 +670,7 @@ t.test('With directives', t => {
                 schema: 1,
                 parentSchema: {
                   $id: 'https://mercurius.dev/validation/Filters/text',
-                  type: 'string',
+                  type: ['string', 'null'],
                   minLength: 1
                 },
                 data: ''
@@ -1082,7 +1082,7 @@ t.test('With directives', t => {
                   type: 'object',
                   properties: {
                     text: {
-                      type: 'string',
+                      type: ['string', 'null'],
                       $id: 'https://mercurius.dev/validation/Filters/text'
                     }
                   }
@@ -1176,7 +1176,7 @@ t.test('With directives', t => {
                   properties: {
                     text: {
                       minLength: 1,
-                      type: 'string',
+                      type: ['string', 'null'],
                       $id: 'https://mercurius.dev/validation/Filters/text'
                     }
                   }
@@ -1196,7 +1196,7 @@ t.test('With directives', t => {
                 schema: 1,
                 parentSchema: {
                   minLength: 1,
-                  type: 'string',
+                  type: ['string', 'null'],
                   $id: 'https://mercurius.dev/validation/Filters/text'
                 },
                 data: ''

--- a/test/gateway-validation.js
+++ b/test/gateway-validation.js
@@ -99,6 +99,7 @@ async function createTestGatewayServer (t, validationOptions) {
     type User @key(fields: "id") @extends {
       id: ID! @external
       topPosts(count: Int!): [Post]
+      topPostsFloat(count: Float!): [Post]
     }`
 
   const postServiceResolvers = {
@@ -115,6 +116,9 @@ async function createTestGatewayServer (t, validationOptions) {
     },
     User: {
       topPosts: (user, { count }, context, info) => {
+        return Object.values(posts).filter(p => p.authorId === user.id).slice(0, count)
+      },
+      topPostsFloat: (user, { count }, context, info) => {
         return Object.values(posts).filter(p => p.authorId === user.id).slice(0, count)
       }
     },
@@ -148,6 +152,9 @@ async function createTestGatewayServer (t, validationOptions) {
       User: {
         topPosts: {
           count: { type: 'integer', minimum: 1 }
+        },
+        topPostsFloat: {
+          count: { type: 'number', minimum: 1 }
         }
       }
     }
@@ -175,6 +182,12 @@ t.test('Gateway validation', t => {
               id
             }
           }
+          topPostsFloat(count: 2) {
+            pid
+            author {
+              id
+            }
+          }
         }
         topPosts(count: 2) {
           pid
@@ -195,6 +208,20 @@ t.test('Gateway validation', t => {
           name: 'John',
           nickname: 'John',
           topPosts: [
+            {
+              pid: 'p1',
+              author: {
+                id: 'u1'
+              }
+            },
+            {
+              pid: 'p3',
+              author: {
+                id: 'u1'
+              }
+            }
+          ],
+          topPostsFloat: [
             {
               pid: 'p1',
               author: {
@@ -291,7 +318,7 @@ t.test('Gateway validation', t => {
                 schema: 1,
                 parentSchema: {
                   $id: 'https://mercurius.dev/validation/Query/me/id',
-                  type: 'integer',
+                  type: ['integer', 'null'],
                   minimum: 1
                 },
                 data: 0
@@ -326,7 +353,7 @@ t.test('Gateway validation', t => {
                 schema: 1,
                 parentSchema: {
                   $id: 'https://mercurius.dev/validation/Query/topPosts/count',
-                  type: 'integer',
+                  type: ['integer', 'null'],
                   minimum: 1
                 },
                 data: -2

--- a/test/json-schema-validation.js
+++ b/test/json-schema-validation.js
@@ -69,7 +69,7 @@ const resolvers = {
 }
 
 t.test('JSON Schema validators', t => {
-  t.plan(17)
+  t.plan(18)
 
   t.test('should protect the schema and not affect operations when everything is okay', async (t) => {
     t.plan(1)
@@ -276,7 +276,7 @@ t.test('JSON Schema validators', t => {
                 schema: 1,
                 parentSchema: {
                   $id: 'https://mercurius.dev/validation/Filters/text',
-                  type: 'string',
+                  type: ['string', 'null'],
                   minLength: 1
                 },
                 data: ''
@@ -349,7 +349,7 @@ t.test('JSON Schema validators', t => {
                 schema: 1,
                 parentSchema: {
                   $id: 'https://mercurius.dev/validation/Filters/text',
-                  type: 'string',
+                  type: ['string', 'null'],
                   minLength: 1
                 },
                 data: ''
@@ -570,7 +570,7 @@ t.test('JSON Schema validators', t => {
                 schema: 1,
                 parentSchema: {
                   $id: 'https://mercurius.dev/validation/Filters/text',
-                  type: 'string',
+                  type: ['string', 'null'],
                   minLength: 1
                 },
                 data: ''
@@ -958,7 +958,7 @@ t.test('JSON Schema validators', t => {
                   type: 'object',
                   properties: {
                     text: {
-                      type: 'string',
+                      type: ['string', 'null'],
                       $id: 'https://mercurius.dev/validation/Filters/text'
                     }
                   }
@@ -1043,7 +1043,7 @@ t.test('JSON Schema validators', t => {
                   properties: {
                     text: {
                       minLength: 1,
-                      type: 'string',
+                      type: ['string', 'null'],
                       $id: 'https://mercurius.dev/validation/Filters/text'
                     }
                   }
@@ -1063,7 +1063,7 @@ t.test('JSON Schema validators', t => {
                 schema: 1,
                 parentSchema: {
                   minLength: 1,
-                  type: 'string',
+                  type: ['string', 'null'],
                   $id: 'https://mercurius.dev/validation/Filters/text'
                 },
                 data: ''
@@ -1265,7 +1265,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must NOT have fewer than 1 characters',
                 schema: 1,
                 parentSchema: {
-                  type: 'string',
+                  type: ['string', 'null'],
                   $id: 'https://mercurius.dev/validation/Query/message/id',
                   minLength: 1
                 },
@@ -1299,7 +1299,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must NOT have fewer than 1 characters',
                 schema: 1,
                 parentSchema: {
-                  type: 'string',
+                  type: ['string', 'null'],
                   $id: 'https://mercurius.dev/validation/Filters/text',
                   minLength: 1
                 },
@@ -1315,7 +1315,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must NOT have fewer than 1 characters',
                 schema: 1,
                 parentSchema: {
-                  type: 'string',
+                  type: ['string', 'null'],
                   $id: 'https://mercurius.dev/validation/Filters/text',
                   minLength: 1
                 },
@@ -1331,7 +1331,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must NOT have fewer than 1 characters',
                 schema: 1,
                 parentSchema: {
-                  type: 'string',
+                  type: ['string', 'null'],
                   minLength: 1
                 },
                 data: ''
@@ -1373,7 +1373,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must NOT have fewer than 1 characters',
                 schema: 1,
                 parentSchema: {
-                  type: 'string',
+                  type: ['string', 'null'],
                   $id: 'https://mercurius.dev/validation/Filters/text',
                   minLength: 1
                 },
@@ -1501,7 +1501,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must be >= 1',
                 schema: 1,
                 parentSchema: {
-                  type: 'integer',
+                  type: ['integer', 'null'],
                   $id: 'https://mercurius.dev/validation/Query/message/id',
                   minimum: 1
                 },
@@ -1536,7 +1536,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must be >= 1',
                 schema: 1,
                 parentSchema: {
-                  type: 'integer',
+                  type: ['integer', 'null'],
                   $id: 'https://mercurius.dev/validation/Filters/value',
                   minimum: 1
                 },
@@ -1553,7 +1553,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must be >= 1',
                 schema: 1,
                 parentSchema: {
-                  type: 'integer',
+                  type: ['integer', 'null'],
                   $id: 'https://mercurius.dev/validation/Filters/value',
                   minimum: 1
                 },
@@ -1570,7 +1570,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must be >= 1',
                 schema: 1,
                 parentSchema: {
-                  type: 'integer',
+                  type: ['integer', 'null'],
                   minimum: 1
                 },
                 data: 0
@@ -1613,7 +1613,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must be >= 1',
                 schema: 1,
                 parentSchema: {
-                  type: 'integer',
+                  type: ['integer', 'null'],
                   $id: 'https://mercurius.dev/validation/Filters/value',
                   minimum: 1
                 },
@@ -1741,7 +1741,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must be >= 1',
                 schema: 1,
                 parentSchema: {
-                  type: 'number',
+                  type: ['number', 'null'],
                   $id: 'https://mercurius.dev/validation/Query/message/id',
                   minimum: 1
                 },
@@ -1776,7 +1776,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must be >= 1',
                 schema: 1,
                 parentSchema: {
-                  type: 'number',
+                  type: ['number', 'null'],
                   $id: 'https://mercurius.dev/validation/Filters/value',
                   minimum: 1
                 },
@@ -1793,7 +1793,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must be >= 1',
                 schema: 1,
                 parentSchema: {
-                  type: 'number',
+                  type: ['number', 'null'],
                   $id: 'https://mercurius.dev/validation/Filters/value',
                   minimum: 1
                 },
@@ -1810,7 +1810,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must be >= 1',
                 schema: 1,
                 parentSchema: {
-                  type: 'number',
+                  type: ['number', 'null'],
                   minimum: 1
                 },
                 data: 0
@@ -1853,7 +1853,7 @@ t.test('JSON Schema validators', t => {
                 message: 'must be >= 1',
                 schema: 1,
                 parentSchema: {
-                  type: 'number',
+                  type: ['number', 'null'],
                   $id: 'https://mercurius.dev/validation/Filters/value',
                   minimum: 1
                 },
@@ -2049,6 +2049,44 @@ t.test('JSON Schema validators', t => {
           }
         }
       ]
+    })
+  })
+
+  t.test('should support nullable input type arguments', async (t) => {
+    t.plan(1)
+
+    const app = Fastify()
+    t.teardown(app.close.bind(app))
+
+    app.register(mercurius, {
+      schema: `type Query {
+        nullableInput(input: String): String
+      }`,
+      resolvers: {
+        Query: {
+          nullableInput: async (_, { input }) => {
+            return input
+          }
+        }
+      }
+    })
+    app.register(mercuriusValidation)
+
+    const query = `query {
+      nullableInput(input: null)
+    }`
+
+    const response = await app.inject({
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      url: '/graphql',
+      body: JSON.stringify({ query })
+    })
+
+    t.same(response.json(), {
+      data: {
+        nullableInput: null
+      }
     })
   })
 })

--- a/test/refresh.js
+++ b/test/refresh.js
@@ -276,7 +276,7 @@ t.test('gateway refresh', t => {
                   schema: 1,
                   parentSchema: {
                     $id: 'https://mercurius.dev/validation/Filters/text',
-                    type: 'string',
+                    type: ['string', 'null'],
                     minLength: 1
                   },
                   data: ''


### PR DESCRIPTION
Closes #30 

Note that this is the fastest solution to the issue I came up with but I'm not 100% sure that this covers all scenarios or that it doesn't break anything.

The change is minimal but has cascading consequences on many assertions in tests because most types and fields are nullable, therefore will see their json-schema type change from 'whatever' to ['whatever', 'null'].

The scenario raised by the OP is covered and works fine.