### PR TITLE
build(deps): migrate to @fastify/error

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const createError = require('fastify-error')
+const createError = require('@fastify/error')
 
 class ValidationError extends Error {
   constructor (message, details) {

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "wait-on": "^6.0.0"
   },
   "dependencies": {
+    "@fastify/error": "^2.0.0",
     "ajv": "^8.6.2",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^2.1.1",
-    "fastify-error": "^1.0.0",
     "fastify-plugin": "^3.0.0",
     "graphql": "^16.2.0"
   },


### PR DESCRIPTION
`fastify-error` has been deprecated as the module has been moved to `@fastify/error`