### PR TITLE
Return status code 400 for validation errors

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -12,6 +12,7 @@ class ValidationError extends Error {
       code: this.code,
       details
     }
+    this.statusCode = 400
     ValidationError.prototype[Symbol.toStringTag] = 'Error'
     ValidationError.prototype.toString = function () {
       return `${this.name} [${this.code}]: ${this.message}`

--- a/test/errors.js
+++ b/test/errors.js
@@ -13,11 +13,12 @@ t.test('errors', t => {
       t.plan(1)
 
       t.test('should print a validation error to string', t => {
-        t.plan(1)
+        t.plan(2)
 
         const error = new errors.MER_VALIDATION_ERR_FAILED_VALIDATION('some message', [])
 
         t.same(error.toString(), 'ValidationError [MER_VALIDATION_ERR_FAILED_VALIDATION]: some message')
+        t.equal(error.statusCode, 400)
       })
     })
   })


### PR DESCRIPTION
Errors in validation mean the client sent something invalid, so
the response status code should be 400 (Bad Request) rather
than the default status code of 500 (Internal Server Error).

Fixes #51 